### PR TITLE
[Fix] Unblock downstream forge install by updating .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,12 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url  = https://github.com/openzeppelin/openzeppelin-contracts.git
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/openZeppelin/openzeppelin-contracts-upgradeable
 [submodule "lib/openzeppelin-foundry-upgrades"]
 	path = lib/openzeppelin-foundry-upgrades
 	url = https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades
-


### PR DESCRIPTION
**Fixed**

- `forge install bandprotocol/tunnel‑tss‑router‑contracts` aborted with `fatal: No url found for submodule path 'lib/openzeppelin-contracts' in .gitmodules` because that submodule was not declared in .gitmodules.

### Implementation details

- Added a new section to `.gitmodules`:
  ```ini
  [submodule "lib/openzeppelin-contracts"]
	  path = lib/openzeppelin-contracts
	  url  = https://github.com/openzeppelin/openzeppelin-contracts.git
  ```
- Executed `forge test` in this repo; all existing tests pass.
- Verified that a fresh Foundry project (forge init … && forge install bandprotocol/tunnel-tss-router-contracts) now installs successfully with no errors.

## Please ensure the following requirements are met before submitting a pull request:

- [ ] The pull request is targeted against the correct target branch
- [ ] The pull request is linked to an issue with appropriate discussion and an accepted design OR is linked to a spec that describes the work.
- [ ] The pull request includes a description of the implementation/work done in detail.
- [ ] The pull request includes any and all appropriate unit/integration tests
- [ ] You have added a relevant changelog entry to `CHANGELOG_UNRELEASED.md`
- [ ] You have re-reviewed the files affected by the pull request (e.g. using the `Files changed` tab in the Github PR explorer)